### PR TITLE
fix(release-container-image.yaml): trigger action on release of a new tag

### DIFF
--- a/.github/workflows/release-container-image.yaml
+++ b/.github/workflows/release-container-image.yaml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '3 3 * * *'
   pull_request:
+  release:
+    types: [published]
   push:
     branches: master
     tags:


### PR DESCRIPTION
The creation of a new tag by our bump version action isn't triggering a "tagged" `GH_REF` action for the `container-image-release.yaml` this is trying to solve the issue.